### PR TITLE
update `actions/deploy-pages` version to v4

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -75,4 +75,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Attempting to resolve https://github.com/hydra-synth/hydra-docs-v2/issues/14.

As [previously noted](https://github.com/hydra-synth/hydra-docs-v2/issues/14#issuecomment-2795466163), on a preview render the demos were broken, but it's unclear if they would work once merged to the main repo. 