### PR TITLE
Add Catalan language entry to config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,6 +28,10 @@ enableGitInfo = true
   languageName = 'Portuguese | Português'
   contentDir = 'content.pt'
   weight = 3
+[languages.ca]
+languageName = "Català"
+contentDir = 'content.ca'
+weight = 4
 
 [menu]
 # [[menu.before]]


### PR DESCRIPTION
This PR adds Catalan (ca) to the list of supported languages in the config.toml file:

[languages.ca]
languageName = "Català"
contentDir = 'content.ca'
weight = 4

This change ensures that the Catalan translations (e.g., “Quick Start” and “Learning”) already added to content/ca/ are properly linked and visible in the language selector on the Hydra documentation site.

This follows the same format as the existing entries for English, Japanese, and Portuguese.

Thanks for your time and consideration!
Arnau Casanoves de la Hoz